### PR TITLE
Fix: WR cache event type description

### DIFF
--- a/body.adoc
+++ b/body.adoc
@@ -227,7 +227,7 @@ The second level of the CACHE event hierarchy identifies the access or operation
 | RD | Data reads that lookup the cache.  This includes explicit reads (e.g., the LW instruction) and implicit reads (e.g., page table walks).  
 | RD.DATA | The subset of reads that are data load operations.
 | RD.CODE | The subset of reads that are code fetch reads.
-| WR | Data writes to the cache.  This includes explicit reads (e.g., the SW instruction) and implicit reads (e.g., page accessed/dirty attribute updates).  
+| WR | Data writes to the cache.  This includes explicit writes (e.g., the SW instruction) and implicit writes (e.g., page accessed/dirty attribute updates).
 | RW | Data reads and writes, the union of the RD and WR types above.
 | PREF | Prefetch requests that lookup the cache.
 | FILL  | Cache misses or prefetches that result in a line in the cache being filled with data from memory or a higher-level cache.


### PR DESCRIPTION
The WR cache event type description mentions "explicit reads" and "implicit reads" on it (see Table 14 of latest pdf release [here](https://github.com/riscv/riscv-performance-events/releases/download/v0.0.1/riscv-perf-events-v0.0.1.pdf)).
Probably a copy-paste from the RD cache event type.
Changed them to "explicit writes" and "implicit writes".

Signed-off-by: Daniel Gracia Pérez daniel.gracia-perez@thalesgroup.com